### PR TITLE
feat(domain): implementar patron Strategy para politicas de aprobacion

### DIFF
--- a/backend/domain/factories.py
+++ b/backend/domain/factories.py
@@ -80,20 +80,20 @@ class ProductiveDatabaseFlowFactory(ApprovalFlowFactory):
     """
     def create_approval_pipeline(self) -> List[UserRole]:
         return [UserRole.SECURITY_REVIEWER, UserRole.MANAGER]
-
-# ============================================================
-# Selector Automático de Factory
-# ============================================================
-
-def get_approval_flow_factory(request: AccessRequest) -> ApprovalFlowFactory:
-    """
-    Evalúa el contexto de la solicitud y retorna la fábrica de
-    flujo de aprobación correspondiente.
-    """
-    if request.system_type == SystemType.PRODUCTIVE_DATABASE:
-        return ProductiveDatabaseFlowFactory()
     
-    if request.access_level == AccessLevel.ADMIN:
-        return AdminApprovalFlowFactory()
+    # ============================================================
+    # Selector Automático de Factory
+    # ============================================================
+
+    def get_approval_flow_factory(request: AccessRequest) -> ApprovalFlowFactory:
+        """
+        Evalúa el contexto de la solicitud y retorna la fábrica de
+        flujo de aprobación correspondiente.
+        """
+        if request.system_type == SystemType.PRODUCTIVE_DATABASE:
+            return ProductiveDatabaseFlowFactory()
         
-    return StandardApprovalFlowFactory()
+        if request.access_level == AccessLevel.ADMIN:
+            return AdminApprovalFlowFactory()
+            
+        return StandardApprovalFlowFactory()

--- a/backend/domain/factories.py
+++ b/backend/domain/factories.py
@@ -29,7 +29,6 @@ class AccessRequestFactory:
         manager_id: Optional[str] = None
     ) -> AccessRequest:
         
-        # Validación temprana de expiración obligatoria para ADMIN
         if access_level == AccessLevel.ADMIN and expiration_date is None:
             raise ExpirationRequiredError(
                 "Los accesos de nivel ADMIN requieren una fecha de expiración obligatoria."
@@ -48,52 +47,66 @@ class AccessRequestFactory:
 
 
 # ============================================================
+# Approval Steps
+# ============================================================
+
+class ApprovalStep(ABC):
+    """Objeto que representa un paso individual en el pipeline de aprobación."""
+    @abstractmethod
+    def get_role(self) -> UserRole:
+        pass
+        
+    @abstractmethod
+    def get_step_name(self) -> str:
+        pass
+
+
+class ManagerApprovalStep(ApprovalStep):
+    def get_role(self) -> UserRole:
+        return UserRole.MANAGER
+        
+    def get_step_name(self) -> str:
+        return "MANAGER_REVIEW"
+
+
+class SecurityApprovalStep(ApprovalStep):
+    def get_role(self) -> UserRole:
+        return UserRole.SECURITY_REVIEWER
+        
+    def get_step_name(self) -> str:
+        return "SECURITY_REVIEW"
+
+
+# ============================================================
 # Approval Flow Factories (Abstract Factory Pattern)
 # ============================================================
 
 class ApprovalFlowFactory(ABC):
     """
     Abstract Factory para crear pipelines de aprobación.
-    Devuelve una lista ordenada de roles que deben aprobar la solicitud.
+    Devuelve una lista ordenada de objetos ApprovalStep.
     """
     @abstractmethod
-    def create_approval_pipeline(self) -> List[UserRole]:
+    def create_approval_pipeline(self) -> List[ApprovalStep]:
         pass
 
 
 class StandardApprovalFlowFactory(ApprovalFlowFactory):
     """Flujo estándar: Solo requiere la aprobación del Manager directo."""
-    def create_approval_pipeline(self) -> List[UserRole]:
-        return [UserRole.MANAGER]
+    def create_approval_pipeline(self) -> List[ApprovalStep]:
+        return [ManagerApprovalStep()]
 
 
 class AdminApprovalFlowFactory(ApprovalFlowFactory):
     """Flujo Admin: Requiere primero al Manager, luego al equipo de Seguridad."""
-    def create_approval_pipeline(self) -> List[UserRole]:
-        return [UserRole.MANAGER, UserRole.SECURITY_REVIEWER]
+    def create_approval_pipeline(self) -> List[ApprovalStep]:
+        return [ManagerApprovalStep(), SecurityApprovalStep()]
 
 
 class ProductiveDatabaseFlowFactory(ApprovalFlowFactory):
     """
     Flujo para Bases de Datos Productivas: 
-    Requiere primero a Seguridad (para evaluar riesgo inmediato) y luego al Manager.
+    Requiere primero a Seguridad (riesgo inmediato) y luego al Manager.
     """
-    def create_approval_pipeline(self) -> List[UserRole]:
-        return [UserRole.SECURITY_REVIEWER, UserRole.MANAGER]
-    
-    # ============================================================
-    # Selector Automático de Factory
-    # ============================================================
-
-    def get_approval_flow_factory(request: AccessRequest) -> ApprovalFlowFactory:
-        """
-        Evalúa el contexto de la solicitud y retorna la fábrica de
-        flujo de aprobación correspondiente.
-        """
-        if request.system_type == SystemType.PRODUCTIVE_DATABASE:
-            return ProductiveDatabaseFlowFactory()
-        
-        if request.access_level == AccessLevel.ADMIN:
-            return AdminApprovalFlowFactory()
-            
-        return StandardApprovalFlowFactory()
+    def create_approval_pipeline(self) -> List[ApprovalStep]:
+        return [SecurityApprovalStep(), ManagerApprovalStep()]

--- a/backend/domain/strategies.py
+++ b/backend/domain/strategies.py
@@ -1,0 +1,79 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from domain.entities import AccessRequest
+from domain.enums import AccessLevel, SystemType, UserRole
+from domain.factories import (
+    AdminApprovalFlowFactory,
+    ApprovalFlowFactory,
+    ProductiveDatabaseFlowFactory,
+    StandardApprovalFlowFactory,
+)
+
+
+# ============================================================
+# Interfaz del Strategy
+# ============================================================
+
+class ApprovalPolicy(ABC):
+    """
+    Interfaz Strategy para determinar la política de aprobación.
+    Define el contrato para generar el pipeline de revisores.
+    """
+    @abstractmethod
+    def get_approval_pipeline(self) -> List[UserRole]:
+        """Retorna la lista de roles requeridos para la aprobación."""
+        pass
+
+
+# ============================================================
+# Estrategias Concretas
+# ============================================================
+
+class StandardApprovalPolicy(ApprovalPolicy):
+    """Política para accesos básicos (READ/WRITE) en sistemas comunes."""
+    def __init__(self, factory: ApprovalFlowFactory = StandardApprovalFlowFactory()):
+        self.factory = factory
+
+    def get_approval_pipeline(self) -> List[UserRole]:
+        return self.factory.create_approval_pipeline()
+
+
+class AdminApprovalPolicy(ApprovalPolicy):
+    """Política de alta seguridad para accesos ADMIN."""
+    def __init__(self, factory: ApprovalFlowFactory = AdminApprovalFlowFactory()):
+        self.factory = factory
+
+    def get_approval_pipeline(self) -> List[UserRole]:
+        return self.factory.create_approval_pipeline()
+
+
+class ProductiveDatabasePolicy(ApprovalPolicy):
+    """Política crítica para cualquier acceso a bases de datos productivas."""
+    def __init__(self, factory: ApprovalFlowFactory = ProductiveDatabaseFlowFactory()):
+        self.factory = factory
+
+    def get_approval_pipeline(self) -> List[UserRole]:
+        return self.factory.create_approval_pipeline()
+
+
+# ============================================================
+# Selector Automático (Context)
+# ============================================================
+
+def determine_approval_policy(request: AccessRequest) -> ApprovalPolicy:
+    """
+    Función que evalúa el contexto de la solicitud (AccessRequest)
+    y retorna dinámicamente la estrategia de aprobación correcta.
+    """
+    
+    # Prioridad 1: Bases de datos productivas (Máxima criticidad)
+    if request.system_type == SystemType.PRODUCTIVE_DATABASE:
+        return ProductiveDatabasePolicy()
+    
+    # Prioridad 2: Nivel de acceso ADMIN
+    if request.access_level == AccessLevel.ADMIN:
+        return AdminApprovalPolicy()
+        
+    # Prioridad 3: Accesos estándar (READ o WRITE en sistemas no críticos)
+    return StandardApprovalPolicy()

--- a/backend/domain/strategies.py
+++ b/backend/domain/strategies.py
@@ -2,10 +2,11 @@ from abc import ABC, abstractmethod
 from typing import List
 
 from domain.entities import AccessRequest
-from domain.enums import AccessLevel, SystemType, UserRole
+from domain.enums import AccessLevel, SystemType
 from domain.factories import (
     AdminApprovalFlowFactory,
     ApprovalFlowFactory,
+    ApprovalStep,
     ProductiveDatabaseFlowFactory,
     StandardApprovalFlowFactory,
 )
@@ -18,11 +19,11 @@ from domain.factories import (
 class ApprovalPolicy(ABC):
     """
     Interfaz Strategy para determinar la política de aprobación.
-    Define el contrato para generar el pipeline de revisores.
+    Define el contrato para generar el pipeline de pasos de revisión.
     """
     @abstractmethod
-    def get_approval_pipeline(self) -> List[UserRole]:
-        """Retorna la lista de roles requeridos para la aprobación."""
+    def get_approval_pipeline(self) -> List[ApprovalStep]:
+        """Retorna la lista de pasos requeridos para la aprobación."""
         pass
 
 
@@ -35,7 +36,7 @@ class StandardApprovalPolicy(ApprovalPolicy):
     def __init__(self, factory: ApprovalFlowFactory = StandardApprovalFlowFactory()):
         self.factory = factory
 
-    def get_approval_pipeline(self) -> List[UserRole]:
+    def get_approval_pipeline(self) -> List[ApprovalStep]:
         return self.factory.create_approval_pipeline()
 
 
@@ -44,7 +45,7 @@ class AdminApprovalPolicy(ApprovalPolicy):
     def __init__(self, factory: ApprovalFlowFactory = AdminApprovalFlowFactory()):
         self.factory = factory
 
-    def get_approval_pipeline(self) -> List[UserRole]:
+    def get_approval_pipeline(self) -> List[ApprovalStep]:
         return self.factory.create_approval_pipeline()
 
 
@@ -53,7 +54,7 @@ class ProductiveDatabasePolicy(ApprovalPolicy):
     def __init__(self, factory: ApprovalFlowFactory = ProductiveDatabaseFlowFactory()):
         self.factory = factory
 
-    def get_approval_pipeline(self) -> List[UserRole]:
+    def get_approval_pipeline(self) -> List[ApprovalStep]:
         return self.factory.create_approval_pipeline()
 
 


### PR DESCRIPTION
Implementa el patrón Strategy en `domain/strategies.py` para definir las políticas de aprobación dinámicas.

### Criterios cumplidos:
- `StandardApprovalPolicy` retorna `[MANAGER]`.
- `AdminApprovalPolicy` retorna `[MANAGER, SECURITY]`.
- `ProductiveDatabasePolicy` retorna `[SECURITY, MANAGER]`.
- Se incluye `determine_approval_policy` para la selección automática basada en el contexto de la `AccessRequest`.

Closes #85