### PR TITLE
feat(api): implementar endpoints REST reales y casos de uso para Access Requests

### DIFF
--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -6,6 +6,13 @@ from domain.entities import User
 from infrastructure.auth_provider import AuthProvider
 from infrastructure.mock_db import MockUserRepository
 
+from infrastructure.mock_db import MockRequestRepository, MockEventBus
+from application.use_cases import AccessRequestUseCases
+
+# Instancias en memoria para que sobrevivan a las peticiones
+request_repo_instance = MockRequestRepository()
+event_bus_instance = MockEventBus()
+
 # Le indica a FastAPI y a Swagger/OpenAPI dónde está el endpoint para pedir el token
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 
@@ -44,3 +51,17 @@ def get_current_user(
         raise credentials_exception
         
     return user
+
+
+def get_request_repository():
+    return request_repo_instance
+
+def get_event_bus():
+    return event_bus_instance
+
+def get_access_request_use_cases(
+    repo = Depends(get_request_repository),
+    bus = Depends(get_event_bus)
+) -> AccessRequestUseCases:
+    """Inyecta la capa de aplicación con sus dependencias resueltas."""
+    return AccessRequestUseCases(repo, bus)

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -15,8 +15,22 @@ from application.use_cases import AccessRequestUseCases
 
 router = APIRouter(tags=["AccessFlow API"])
 
+# Helper para mapear la respuesta
+def map_to_response(req) -> AccessRequestResponse:
+    return AccessRequestResponse(
+        id=str(req.id),
+        requester_id=req.requester_id,
+        target_system=req.target_system,
+        access_level=req.access_level.value,
+        justification=req.justification,
+        system_type=req.system_type.value,
+        expiration_date=req.expiration_date,
+        status=req.status.value,
+        created_at=req.created_at
+    )
+
 # ============================================================
-# Auth Endpoints (Issue 89)
+# Auth Endpoints
 # ============================================================
 
 @router.post("/auth/login", response_model=TokenResponse, tags=["Authentication"])
@@ -45,7 +59,7 @@ def login(request: LoginRequest, user_repo = Depends(get_user_repository)):
     )
 
 # ============================================================
-# Access Request Endpoints (Issue 91)
+# Access Request Endpoints
 # ============================================================
 
 @router.post("/requests", status_code=status.HTTP_201_CREATED, response_model=AccessRequestResponse, tags=["Access Requests"])
@@ -55,14 +69,15 @@ def create_access_request(
     use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
     req = use_cases.create_request(payload, current_user)
-    return AccessRequestResponse(id=str(req.id), requester_id=req.requester_id, target_system=req.target_system, access_level=req.access_level.value, status=req.status.value, created_at=req.created_at)
+    return map_to_response(req)
 
 @router.get("/requests", response_model=List[AccessRequestResponse], tags=["Access Requests"])
 def list_requests(
     current_user: User = Depends(get_current_user),
     use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    return [AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at) for r in use_cases.repo.get_all()]
+    requests = use_cases.list_requests(current_user)
+    return [map_to_response(r) for r in requests]
 
 @router.get("/requests/{request_id}", response_model=AccessRequestResponse, tags=["Access Requests"])
 def get_request_detail(
@@ -70,8 +85,8 @@ def get_request_detail(
     current_user: User = Depends(get_current_user),
     use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    r = use_cases.get_request(request_id)
-    return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
+    req = use_cases.get_request(request_id)
+    return map_to_response(req)
 
 @router.post("/requests/{request_id}/approve", response_model=AccessRequestResponse, tags=["Access Requests"])
 def approve_request(
@@ -79,8 +94,8 @@ def approve_request(
     current_user: User = Depends(require_any_role([UserRole.MANAGER, UserRole.SECURITY_REVIEWER])),
     use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    r = use_cases.approve_request(request_id, current_user)
-    return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
+    req = use_cases.approve_request(request_id, current_user)
+    return map_to_response(req)
 
 @router.post("/requests/{request_id}/reject", response_model=AccessRequestResponse, tags=["Access Requests"])
 def reject_request(
@@ -89,20 +104,39 @@ def reject_request(
     current_user: User = Depends(require_any_role([UserRole.MANAGER, UserRole.SECURITY_REVIEWER])),
     use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    r = use_cases.reject_request(request_id, current_user, payload.reason)
-    return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
+    req = use_cases.reject_request(request_id, current_user, payload.reason)
+    return map_to_response(req)
+
+@router.post("/requests/{request_id}/request-changes", response_model=AccessRequestResponse, tags=["Access Requests"])
+def request_changes(
+    request_id: str,
+    payload: ActionReasonDTO,
+    current_user: User = Depends(require_any_role([UserRole.MANAGER, UserRole.SECURITY_REVIEWER])),
+    use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
+):
+    req = use_cases.request_changes(request_id, current_user, payload.reason)
+    return map_to_response(req)
+
+@router.post("/requests/{request_id}/cancel", response_model=AccessRequestResponse, tags=["Access Requests"])
+def cancel_request(
+    request_id: str,
+    current_user: User = Depends(get_current_user),
+    use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
+):
+    req = use_cases.cancel_request(request_id, current_user)
+    return map_to_response(req)
 
 @router.post("/requests/{request_id}/provision", response_model=AccessRequestResponse, tags=["Access Requests"])
 def provision_request(
     request_id: str,
-    current_user: User = Depends(require_role(UserRole.IT_ADMIN)),
+    current_user: User = Depends(require_any_role([UserRole.IT_ADMIN, UserRole.SYSTEM_ADMIN])),
     use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    r = use_cases.provision_request(request_id, current_user)
-    return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
+    req = use_cases.provision_request(request_id, current_user)
+    return map_to_response(req)
 
 # ============================================================
-# Utility Endpoints (Mocks)
+# Utility Endpoints (Mocks pendientes Issue de Observers)
 # ============================================================
 
 @router.get("/notifications", response_model=List[NotificationResponse], tags=["Utility"])

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -8,6 +8,14 @@ from api.guards import require_role, require_any_role
 from domain.enums import UserRole
 from domain.entities import User
 
+from typing import List
+from application.dtos import (
+    CreateAccessRequestDTO, AccessRequestResponse, ActionReasonDTO, 
+    NotificationResponse, AuditLogResponse
+)
+from application.use_cases import AccessRequestUseCases
+from api.dependencies import get_access_request_use_cases
+
 router = APIRouter(tags=["AccessFlow API"])
 
 # ============================================================
@@ -42,55 +50,72 @@ def login(request: LoginRequest, user_repo = Depends(get_user_repository)):
 
 
 # ============================================================
-# Access Request Endpoints (Issue 90)
+# Access Request Endpoints (Issue 91)
 # ============================================================
 
-# Dummy DTO para que no falle el endpoint de crear
-class CreateRequestDTO(BaseModel):
-    target_system: str
-    justification: str
-
-
-@router.post("/requests", status_code=status.HTTP_201_CREATED, tags=["Access Requests"])
+@router.post("/requests", status_code=status.HTTP_201_CREATED, response_model=AccessRequestResponse, tags=["Access Requests"])
 def create_access_request(
-    payload: CreateRequestDTO,
-    # Cualquier rol válido puede crear solicitudes (Employee o superior)
-    current_user: User = Depends(require_any_role([
-        UserRole.EMPLOYEE, 
-        UserRole.MANAGER, 
-        UserRole.SECURITY_REVIEWER, 
-        UserRole.IT_ADMIN
-    ]))
+    payload: CreateAccessRequestDTO,
+    current_user: User = Depends(require_any_role([UserRole.EMPLOYEE, UserRole.MANAGER, UserRole.SECURITY_REVIEWER, UserRole.IT_ADMIN])),
+    use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    """Crea una nueva solicitud de acceso."""
-    return {"message": "Solicitud creada exitosamente", "requester": current_user.email}
+    req = use_cases.create_request(payload, current_user)
+    return AccessRequestResponse(id=str(req.id), requester_id=req.requester_id, target_system=req.target_system, access_level=req.access_level.value, status=req.status.value, created_at=req.created_at)
 
+@router.get("/requests", response_model=List[AccessRequestResponse], tags=["Access Requests"])
+def list_requests(
+    current_user: User = Depends(get_current_user),
+    use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
+):
+    # Por ahora retorna todo el mock, se filtrará por rol en DB real
+    return [AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at) for r in use_cases.repo.get_all()]
 
-@router.post("/requests/{request_id}/approve", tags=["Access Requests"])
+@router.get("/requests/{request_id}", response_model=AccessRequestResponse, tags=["Access Requests"])
+def get_request_detail(
+    request_id: str,
+    current_user: User = Depends(get_current_user),
+    use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
+):
+    r = use_cases.get_request(request_id)
+    return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
+
+# Unificado para Manager o Security. El Use Case (vía Command) valida si el rol es correcto para el estado actual.
+@router.post("/requests/{request_id}/approve", response_model=AccessRequestResponse, tags=["Access Requests"])
 def approve_request(
     request_id: str,
-    # Solo los Managers pueden aprobar el primer paso
-    current_user: User = Depends(require_role(UserRole.MANAGER))
+    current_user: User = Depends(require_any_role([UserRole.MANAGER, UserRole.SECURITY_REVIEWER])),
+    use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    """Aprueba una solicitud en la fase de Manager."""
-    return {"message": f"Solicitud {request_id} aprobada por el manager {current_user.email}"}
+    r = use_cases.approve_request(request_id, current_user)
+    return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
 
-
-@router.post("/requests/{request_id}/security-review", tags=["Access Requests"])
-def security_review_request(
+@router.post("/requests/{request_id}/reject", response_model=AccessRequestResponse, tags=["Access Requests"])
+def reject_request(
     request_id: str,
-    # Solo el equipo de Seguridad puede hacer estas revisiones
-    current_user: User = Depends(require_role(UserRole.SECURITY_REVIEWER))
+    payload: ActionReasonDTO,
+    current_user: User = Depends(require_any_role([UserRole.MANAGER, UserRole.SECURITY_REVIEWER])),
+    use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    """Aprueba o revisa una solicitud en la fase de Seguridad."""
-    return {"message": f"Solicitud {request_id} aprobada por seguridad ({current_user.email})"}
+    r = use_cases.reject_request(request_id, current_user, payload.reason)
+    return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
 
-
-@router.post("/requests/{request_id}/provision", tags=["Access Requests"])
+@router.post("/requests/{request_id}/provision", response_model=AccessRequestResponse, tags=["Access Requests"])
 def provision_request(
     request_id: str,
-    # Solo IT Admin puede dar el acceso final en el sistema real
-    current_user: User = Depends(require_role(UserRole.IT_ADMIN))
+    current_user: User = Depends(require_role(UserRole.IT_ADMIN)),
+    use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    """Ejecuta el aprovisionamiento de una solicitud lista."""
-    return {"message": f"Acceso provisionado para la solicitud {request_id} por {current_user.email}"}
+    r = use_cases.provision_request(request_id, current_user)
+    return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
+
+# ============================================================
+# Utility Endpoints (Mocks por ahora)
+# ============================================================
+
+@router.get("/notifications", response_model=List[NotificationResponse], tags=["Utility"])
+def get_notifications(current_user: User = Depends(get_current_user)):
+    return []
+
+@router.get("/audit-log", response_model=List[AuditLogResponse], tags=["Utility"])
+def get_audit_log(current_user: User = Depends(require_role(UserRole.SYSTEM_ADMIN))):
+    return []

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1,20 +1,17 @@
+from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
 
-from application.dtos import LoginRequest, TokenResponse
+from application.dtos import (
+    LoginRequest, TokenResponse, CreateAccessRequestDTO, 
+    AccessRequestResponse, ActionReasonDTO, 
+    NotificationResponse, AuditLogResponse
+)
 from infrastructure.auth_provider import AuthProvider
-from api.dependencies import get_user_repository
+from api.dependencies import get_user_repository, get_current_user, get_access_request_use_cases
 from api.guards import require_role, require_any_role
 from domain.enums import UserRole
 from domain.entities import User
-
-from typing import List
-from application.dtos import (
-    CreateAccessRequestDTO, AccessRequestResponse, ActionReasonDTO, 
-    NotificationResponse, AuditLogResponse
-)
 from application.use_cases import AccessRequestUseCases
-from api.dependencies import get_access_request_use_cases
 
 router = APIRouter(tags=["AccessFlow API"])
 
@@ -24,7 +21,6 @@ router = APIRouter(tags=["AccessFlow API"])
 
 @router.post("/auth/login", response_model=TokenResponse, tags=["Authentication"])
 def login(request: LoginRequest, user_repo = Depends(get_user_repository)):
-    """Autentica a un usuario validando su email y contraseña."""
     user = user_repo.get_by_email(request.email)
     
     if not user or not AuthProvider.verify_password(request.password, user.hashed_password):
@@ -48,7 +44,6 @@ def login(request: LoginRequest, user_repo = Depends(get_user_repository)):
         role=user.role.value
     )
 
-
 # ============================================================
 # Access Request Endpoints (Issue 91)
 # ============================================================
@@ -67,7 +62,6 @@ def list_requests(
     current_user: User = Depends(get_current_user),
     use_cases: AccessRequestUseCases = Depends(get_access_request_use_cases)
 ):
-    # Por ahora retorna todo el mock, se filtrará por rol en DB real
     return [AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at) for r in use_cases.repo.get_all()]
 
 @router.get("/requests/{request_id}", response_model=AccessRequestResponse, tags=["Access Requests"])
@@ -79,7 +73,6 @@ def get_request_detail(
     r = use_cases.get_request(request_id)
     return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
 
-# Unificado para Manager o Security. El Use Case (vía Command) valida si el rol es correcto para el estado actual.
 @router.post("/requests/{request_id}/approve", response_model=AccessRequestResponse, tags=["Access Requests"])
 def approve_request(
     request_id: str,
@@ -109,7 +102,7 @@ def provision_request(
     return AccessRequestResponse(id=str(r.id), requester_id=r.requester_id, target_system=r.target_system, access_level=r.access_level.value, status=r.status.value, created_at=r.created_at)
 
 # ============================================================
-# Utility Endpoints (Mocks por ahora)
+# Utility Endpoints (Mocks)
 # ============================================================
 
 @router.get("/notifications", response_model=List[NotificationResponse], tags=["Utility"])

--- a/backend/application/dtos.py
+++ b/backend/application/dtos.py
@@ -30,6 +30,9 @@ class AccessRequestResponse(BaseModel):
     requester_id: str
     target_system: str
     access_level: str
+    justification: Optional[str] = None
+    system_type: Optional[str] = None
+    expiration_date: Optional[date] = None
     status: str
     created_at: datetime
 

--- a/backend/application/dtos.py
+++ b/backend/application/dtos.py
@@ -1,5 +1,9 @@
 from pydantic import BaseModel
+from typing import Optional, List
+from datetime import date, datetime
+from domain.enums import AccessLevel, SystemType
 
+# --- Auth DTOs ---
 class LoginRequest(BaseModel):
     email: str
     password: str
@@ -8,3 +12,35 @@ class TokenResponse(BaseModel):
     access_token: str
     token_type: str
     role: str
+
+# --- Access Request DTOs ---
+class CreateAccessRequestDTO(BaseModel):
+    target_system: str
+    access_level: AccessLevel
+    justification: str
+    system_type: SystemType = SystemType.OTHER
+    expiration_date: Optional[date] = None
+    manager_id: Optional[str] = None
+
+class ActionReasonDTO(BaseModel):
+    reason: str
+
+class AccessRequestResponse(BaseModel):
+    id: str
+    requester_id: str
+    target_system: str
+    access_level: str
+    status: str
+    created_at: datetime
+
+# --- Utility DTOs ---
+class NotificationResponse(BaseModel):
+    id: str
+    message: str
+    created_at: datetime
+
+class AuditLogResponse(BaseModel):
+    id: str
+    action: str
+    performed_by: str
+    timestamp: datetime

--- a/backend/application/dtos.py
+++ b/backend/application/dtos.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional, List
+from typing import Optional
 from datetime import date, datetime
 from domain.enums import AccessLevel, SystemType
 

--- a/backend/application/use_cases.py
+++ b/backend/application/use_cases.py
@@ -3,7 +3,8 @@ from domain.entities import User
 from domain.factories import AccessRequestFactory
 from domain.commands import (
     CreateRequestCommand, ApproveRequestCommand, RejectRequestCommand, 
-    ProvisionAccessCommand, RequestChangesCommand, SubmitRequestCommand
+    ProvisionAccessCommand, RequestChangesCommand, SubmitRequestCommand,
+    CancelRequestCommand
 )
 from application.dtos import CreateAccessRequestDTO
 
@@ -36,6 +37,10 @@ class AccessRequestUseCases:
             raise HTTPException(status_code=404, detail="Solicitud no encontrada")
         return request
 
+    def list_requests(self, user: User):
+        # Por ahora retorna todas, luego se filtrará por rol en DB real
+        return self.repo.get_all()
+
     def approve_request(self, request_id: str, reviewer: User):
         request = self.get_request(request_id)
         ApproveRequestCommand(request, self.event_bus, reviewer).execute()
@@ -57,5 +62,11 @@ class AccessRequestUseCases:
     def provision_request(self, request_id: str, admin: User):
         request = self.get_request(request_id)
         ProvisionAccessCommand(request, self.event_bus, admin).execute()
+        self.repo.save(request)
+        return request
+
+    def cancel_request(self, request_id: str, user: User):
+        request = self.get_request(request_id)
+        CancelRequestCommand(request, self.event_bus).execute()
         self.repo.save(request)
         return request

--- a/backend/application/use_cases.py
+++ b/backend/application/use_cases.py
@@ -1,0 +1,64 @@
+from fastapi import HTTPException
+from domain.entities import User
+from domain.factories import AccessRequestFactory
+from domain.commands import (
+    CreateRequestCommand, ApproveRequestCommand, RejectRequestCommand, 
+    ProvisionAccessCommand, CancelRequestCommand, RequestChangesCommand, SubmitRequestCommand
+)
+from application.dtos import CreateAccessRequestDTO
+
+class AccessRequestUseCases:
+    def __init__(self, request_repo, event_bus):
+        self.repo = request_repo
+        self.event_bus = event_bus
+
+    def create_request(self, dto: CreateAccessRequestDTO, user: User):
+        # 1. Usar Factory para crear la entidad
+        request = AccessRequestFactory.create(
+            requester_id=user.id,
+            requester_name=user.name,
+            target_system=dto.target_system,
+            access_level=dto.access_level,
+            justification=dto.justification,
+            system_type=dto.system_type,
+            expiration_date=dto.expiration_date,
+            manager_id=dto.manager_id
+        )
+        
+        # 2. Ejecutar comandos de creación y envío
+        CreateRequestCommand(request, self.event_bus).execute()
+        SubmitRequestCommand(request, self.event_bus).execute()
+        
+        # 3. Guardar en BD
+        self.repo.save(request)
+        return request
+
+    def get_request(self, request_id: str):
+        request = self.repo.get_by_id(request_id)
+        if not request:
+            raise HTTPException(status_code=404, detail="Solicitud no encontrada")
+        return request
+
+    def approve_request(self, request_id: str, reviewer: User):
+        request = self.get_request(request_id)
+        ApproveRequestCommand(request, self.event_bus, reviewer).execute()
+        self.repo.save(request)
+        return request
+
+    def reject_request(self, request_id: str, reviewer: User, reason: str):
+        request = self.get_request(request_id)
+        RejectRequestCommand(request, self.event_bus, reviewer, reason).execute()
+        self.repo.save(request)
+        return request
+
+    def request_changes(self, request_id: str, reviewer: User, comment: str):
+        request = self.get_request(request_id)
+        RequestChangesCommand(request, self.event_bus, reviewer, comment).execute()
+        self.repo.save(request)
+        return request
+
+    def provision_request(self, request_id: str, admin: User):
+        request = self.get_request(request_id)
+        ProvisionAccessCommand(request, self.event_bus, admin).execute()
+        self.repo.save(request)
+        return request

--- a/backend/application/use_cases.py
+++ b/backend/application/use_cases.py
@@ -3,7 +3,7 @@ from domain.entities import User
 from domain.factories import AccessRequestFactory
 from domain.commands import (
     CreateRequestCommand, ApproveRequestCommand, RejectRequestCommand, 
-    ProvisionAccessCommand, CancelRequestCommand, RequestChangesCommand, SubmitRequestCommand
+    ProvisionAccessCommand, RequestChangesCommand, SubmitRequestCommand
 )
 from application.dtos import CreateAccessRequestDTO
 
@@ -13,7 +13,6 @@ class AccessRequestUseCases:
         self.event_bus = event_bus
 
     def create_request(self, dto: CreateAccessRequestDTO, user: User):
-        # 1. Usar Factory para crear la entidad
         request = AccessRequestFactory.create(
             requester_id=user.id,
             requester_name=user.name,
@@ -25,11 +24,9 @@ class AccessRequestUseCases:
             manager_id=dto.manager_id
         )
         
-        # 2. Ejecutar comandos de creación y envío
         CreateRequestCommand(request, self.event_bus).execute()
         SubmitRequestCommand(request, self.event_bus).execute()
         
-        # 3. Guardar en BD
         self.repo.save(request)
         return request
 

--- a/backend/infrastructure/mock_db.py
+++ b/backend/infrastructure/mock_db.py
@@ -21,3 +21,24 @@ class MockUserRepository:
     """Repositorio temporal para no ensuciar la API."""
     def get_by_email(self, email: str) -> User | None:
         return next((u for u in MOCK_USERS_DB if u.email == email), None)
+
+
+class MockRequestRepository:
+    def __init__(self):
+        self.requests = []
+
+    def save(self, request):
+        # Actualiza o inserta
+        self.requests = [r for r in self.requests if r.id != request.id]
+        self.requests.append(request)
+
+    def get_by_id(self, request_id: str):
+        return next((r for r in self.requests if str(r.id) == request_id), None)
+
+    def get_all(self):
+        return self.requests
+
+class MockEventBus:
+    def publish(self, event):
+        # En consola para ver qué eventos se están disparando
+        print(f"[EventBus Mock] Evento publicado: {event.__class__.__name__}")

--- a/backend/infrastructure/mock_db.py
+++ b/backend/infrastructure/mock_db.py
@@ -4,17 +4,35 @@ from infrastructure.auth_provider import AuthProvider
 
 MOCK_USERS_DB = [
     User(
-        name="Admin Prueba", 
-        email="admin@usfq.edu.ec", 
+        name="System Admin", 
+        email="admin@accessflow.com", 
         hashed_password=AuthProvider.get_password_hash("admin123"), 
         role=UserRole.SYSTEM_ADMIN
     ),
     User(
-        name="Empleado Prueba", 
-        email="empleado@usfq.edu.ec", 
-        hashed_password=AuthProvider.get_password_hash("emp123"), 
+        name="Employee", 
+        email="employee@accessflow.com", 
+        hashed_password=AuthProvider.get_password_hash("employee123"), 
         role=UserRole.EMPLOYEE
-    )
+    ),
+    User(
+        name="Manager", 
+        email="manager@accessflow.com", 
+        hashed_password=AuthProvider.get_password_hash("manager123"), 
+        role=UserRole.MANAGER
+    ),
+    User(
+        name="Security Reviewer", 
+        email="security@accessflow.com", 
+        hashed_password=AuthProvider.get_password_hash("security123"), 
+        role=UserRole.SECURITY_REVIEWER
+    ),
+    User(
+        name="IT Admin", 
+        email="itadmin@accessflow.com", 
+        hashed_password=AuthProvider.get_password_hash("itadmin123"), 
+        role=UserRole.IT_ADMIN
+    ),
 ]
 
 class MockUserRepository:
@@ -22,13 +40,11 @@ class MockUserRepository:
     def get_by_email(self, email: str) -> User | None:
         return next((u for u in MOCK_USERS_DB if u.email == email), None)
 
-
 class MockRequestRepository:
     def __init__(self):
         self.requests = []
 
     def save(self, request):
-        # Actualiza o inserta
         self.requests = [r for r in self.requests if r.id != request.id]
         self.requests.append(request)
 
@@ -40,5 +56,4 @@ class MockRequestRepository:
 
 class MockEventBus:
     def publish(self, event):
-        # En consola para ver qué eventos se están disparando
         print(f"[EventBus Mock] Evento publicado: {event.__class__.__name__}")


### PR DESCRIPTION
Implementación de los Casos de Uso y Endpoints REST reales requeridos para el MVP de AccessFlow.

### Criterios y Feedback cumplidos:
- `application/dtos.py`: Migrados y ampliados todos los DTOs de request y response.
- `infrastructure/mock_db.py`: Añadido el repo de requests y event bus simulado (hasta #87).
- `application/use_cases.py`: Orquestación completa aplicando los Commands creados en #83.
- `api/dependencies.py`: Inyección del repo, event bus y el caso de uso central.
- `api/endpoints.py`: Sustituidos los dummies.
  - POST `/requests` retorna 201 y guarda.
  - GET `/requests` y `/{id}` implementados.
  - POST `/{id}/approve` unificado para Managers y Security.
  - POST `/{id}/reject` y `/{id}/provision` implementados con Guards correspondientes.
  - GET `/notifications` y `/audit-log` definidos.

Closes #91