### PR TITLE
feat(api): implementar seeder de usuarios de prueba en startup de Fast API

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,0 +1,59 @@
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+
+from api.endpoints import router as api_router
+from domain.enums import UserRole
+from domain.entities import User
+from infrastructure.auth_provider import AuthProvider
+from api.dependencies import get_user_repository
+
+def seed_test_users():
+    """Verifica y crea los usuarios de prueba en la base de datos si no existen."""
+    user_repo = get_user_repository()
+    
+    users_to_seed = [
+        {"name": "System Admin", "email": "admin@accessflow.com", "password": "admin123", "role": UserRole.SYSTEM_ADMIN},
+        {"name": "Employee", "email": "employee@accessflow.com", "password": "employee123", "role": UserRole.EMPLOYEE},
+        {"name": "Manager", "email": "manager@accessflow.com", "password": "manager123", "role": UserRole.MANAGER},
+        {"name": "Security Reviewer", "email": "security@accessflow.com", "password": "security123", "role": UserRole.SECURITY_REVIEWER},
+        {"name": "IT Admin", "email": "itadmin@accessflow.com", "password": "itadmin123", "role": UserRole.IT_ADMIN},
+    ]
+    
+    for u_data in users_to_seed:
+        # 1. Verifica si no se duplican
+        if not user_repo.get_by_email(u_data["email"]):
+            # 2. Hashea la contraseña con bcrypt
+            hashed_pw = AuthProvider.get_password_hash(u_data["password"])
+            
+            # 3. Asigna el rol correcto
+            new_user = User(
+                name=u_data["name"],
+                email=u_data["email"],
+                hashed_password=hashed_pw,
+                role=u_data["role"]
+            )
+            
+            # 4. Los crea automáticamente
+            user_repo.save(new_user)
+            print(f"✅ Usuario semilla creado: {u_data['email']} [{u_data['role'].value}]")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # --- Startup Event ---
+    print("Iniciando AccessFlow API...")
+    seed_test_users()
+    yield
+    # --- Shutdown Event ---
+    print("Apagando AccessFlow API...")
+
+
+app = FastAPI(
+    title="AccessFlow API",
+    description="API para la gestión y aprobación de accesos en USFQ",
+    version="1.0.0",
+    lifespan=lifespan
+)
+
+# Registrar las rutas
+app.include_router(api_router)

--- a/backend/infrastructure/mock_db.py
+++ b/backend/infrastructure/mock_db.py
@@ -1,4 +1,3 @@
-from domain.enums import UserRole
 from domain.entities import User
 
 # Empezamos con la base de datos vacía para probar que el startup event funciona

--- a/backend/infrastructure/mock_db.py
+++ b/backend/infrastructure/mock_db.py
@@ -2,43 +2,19 @@ from domain.enums import UserRole
 from domain.entities import User
 from infrastructure.auth_provider import AuthProvider
 
-MOCK_USERS_DB = [
-    User(
-        name="System Admin", 
-        email="admin@accessflow.com", 
-        hashed_password=AuthProvider.get_password_hash("admin123"), 
-        role=UserRole.SYSTEM_ADMIN
-    ),
-    User(
-        name="Employee", 
-        email="employee@accessflow.com", 
-        hashed_password=AuthProvider.get_password_hash("employee123"), 
-        role=UserRole.EMPLOYEE
-    ),
-    User(
-        name="Manager", 
-        email="manager@accessflow.com", 
-        hashed_password=AuthProvider.get_password_hash("manager123"), 
-        role=UserRole.MANAGER
-    ),
-    User(
-        name="Security Reviewer", 
-        email="security@accessflow.com", 
-        hashed_password=AuthProvider.get_password_hash("security123"), 
-        role=UserRole.SECURITY_REVIEWER
-    ),
-    User(
-        name="IT Admin", 
-        email="itadmin@accessflow.com", 
-        hashed_password=AuthProvider.get_password_hash("itadmin123"), 
-        role=UserRole.IT_ADMIN
-    ),
-]
+MOCK_USERS_DB = []
 
 class MockUserRepository:
     """Repositorio temporal para no ensuciar la API."""
     def get_by_email(self, email: str) -> User | None:
         return next((u for u in MOCK_USERS_DB if u.email == email), None)
+        
+    def save(self, user: User):
+        global MOCK_USERS_DB
+        # Eliminamos si ya existe para reemplazarlo (simulando un UPSERT)
+        MOCK_USERS_DB = [u for u in MOCK_USERS_DB if u.email != user.email]
+        MOCK_USERS_DB.append(user)
+
 
 class MockRequestRepository:
     def __init__(self):

--- a/backend/infrastructure/mock_db.py
+++ b/backend/infrastructure/mock_db.py
@@ -1,7 +1,7 @@
 from domain.enums import UserRole
 from domain.entities import User
-from infrastructure.auth_provider import AuthProvider
 
+# Empezamos con la base de datos vacía para probar que el startup event funciona
 MOCK_USERS_DB = []
 
 class MockUserRepository:
@@ -14,7 +14,6 @@ class MockUserRepository:
         # Eliminamos si ya existe para reemplazarlo (simulando un UPSERT)
         MOCK_USERS_DB = [u for u in MOCK_USERS_DB if u.email != user.email]
         MOCK_USERS_DB.append(user)
-
 
 class MockRequestRepository:
     def __init__(self):


### PR DESCRIPTION
Implementa un evento de inicio en FastAPI utilizando `lifespan` para verificar y crear dinámicamente los usuarios requeridos en la base de datos al arrancar el servidor.

### Criterios cumplidos:
- Los 5 usuarios (System Admin, Employee, Manager, Security, IT Admin) se crean automáticamente.
- Se evita la duplicación validando mediante `get_by_email` antes de insertar.
- Se implementó `AuthProvider.get_password_hash` para que las contraseñas guarden el hash de bcrypt y funcionen con el endpoint de login.
- Roles asignados correctamente usando el enum `UserRole`.
- Se agregó soporte al mock de repositorio para validar el flujo a la espera de la base de datos real.

Closes #105