### PR TITLE
fix(api): forzar version de bcrypt a 3.2.2 y actualizar endpoint de login para soportar Swagger UI

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,8 +10,8 @@ COPY requirements.txt .
 # Instalar dependencias
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copiar código de la aplicación
-COPY app/ ./app/
+# Copiar TODO el código de la aplicación (estructura hexagonal)
+COPY . .
 
 # Crear usuario no-root para seguridad
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
@@ -24,5 +24,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD python -c "import requests; requests.get('http://localhost:8000/health', timeout=5)" || exit 1
 
-# Comando de inicio
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Comando de inicio corregido
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -1,7 +1,6 @@
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError
-from sqlalchemy.orm import Session
 
 from domain.entities import User
 from infrastructure.auth_provider import AuthProvider

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -1,67 +1,85 @@
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError
+from sqlalchemy.orm import Session
 
 from domain.entities import User
 from infrastructure.auth_provider import AuthProvider
-from infrastructure.mock_db import MockUserRepository
-
-from infrastructure.mock_db import MockRequestRepository, MockEventBus
+from infrastructure.database import SessionLocal
+from infrastructure.postgres import (
+    PostgresUserRepository,
+    PostgresAccessRequestRepository,
+    PostgresNotificationRepository,
+    PostgresAuditLogRepository,
+)
+from infrastructure.event_bus_impl import InMemoryEventBus
+from infrastructure.observers import NotificationObserver, AuditLogObserver
 from application.use_cases import AccessRequestUseCases
 
-# Instancias en memoria para que sobrevivan a las peticiones
-request_repo_instance = MockRequestRepository()
-event_bus_instance = MockEventBus()
+# ---------- Instancias únicas (se inicializan en setup_dependencies) ----------
+user_repo_instance: PostgresUserRepository = None
+request_repo_instance: PostgresAccessRequestRepository = None
+event_bus_instance: InMemoryEventBus = InMemoryEventBus()
 
-# Le indica a FastAPI y a Swagger/OpenAPI dónde está el endpoint para pedir el token
+# ---------- Configuración de OAuth2 ----------
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 
-def get_user_repository():
-    """Inyecta el repositorio. En el futuro se cambiará por PostgresUserRepository."""
-    return MockUserRepository()
+# ---------- Funciones de dependencia ----------
+def get_user_repository() -> PostgresUserRepository:
+    return user_repo_instance
+
+def get_request_repository() -> PostgresAccessRequestRepository:
+    return request_repo_instance
+
+def get_event_bus() -> InMemoryEventBus:
+    return event_bus_instance
 
 def get_current_user(
     token: str = Depends(oauth2_scheme),
-    user_repo: MockUserRepository = Depends(get_user_repository)
+    user_repo: PostgresUserRepository = Depends(get_user_repository)
 ) -> User:
-    """
-    Extrae el token JWT de la cabecera, lo decodifica y busca al usuario
-    correspondiente en el repositorio inyectado.
-    """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="No se pudieron validar las credenciales o el token ha expirado",
         headers={"WWW-Authenticate": "Bearer"},
     )
-    
     try:
-        # 1. Decodificamos el token usando tu AuthProvider
         payload = AuthProvider.decode_token(token)
         email: str | None = payload.get("sub")
         if email is None:
             raise credentials_exception
     except JWTError:
         raise credentials_exception
-        
-    # 2. Buscamos al usuario en la base de datos (mock por ahora)
+
     user = user_repo.get_by_email(email)
-    
-    # 3. Si el usuario ya no existe (ej. fue eliminado), bloqueamos el acceso
     if user is None:
         raise credentials_exception
-        
     return user
 
-
-def get_request_repository():
-    return request_repo_instance
-
-def get_event_bus():
-    return event_bus_instance
-
 def get_access_request_use_cases(
-    repo = Depends(get_request_repository),
-    bus = Depends(get_event_bus)
+    repo: PostgresAccessRequestRepository = Depends(get_request_repository),
+    bus: InMemoryEventBus = Depends(get_event_bus)
 ) -> AccessRequestUseCases:
-    """Inyecta la capa de aplicación con sus dependencias resueltas."""
     return AccessRequestUseCases(repo, bus)
+
+# ---------- Inicialización de dependencias reales ----------
+def setup_dependencies():
+    """Inicializa repositorios reales y suscribe observers al EventBus."""
+    global user_repo_instance, request_repo_instance
+
+    db = SessionLocal()
+
+    # Repositorios reales
+    user_repo_instance = PostgresUserRepository(db)
+    request_repo_instance = PostgresAccessRequestRepository(db)
+
+    # Observers
+    notification_repo = PostgresNotificationRepository(db)
+    audit_repo = PostgresAuditLogRepository(db)
+
+    notif_observer = NotificationObserver(notification_repo, user_repo_instance, db)
+    audit_observer = AuditLogObserver(audit_repo)
+
+    # Suscribir al EventBus
+    event_bus_instance.subscribe(notif_observer)
+    event_bus_instance.subscribe(audit_observer)

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1,6 +1,7 @@
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
 
 from application.dtos import (
     TokenResponse, CreateAccessRequestDTO, 
@@ -13,6 +14,10 @@ from api.guards import require_role, require_any_role
 from domain.enums import UserRole
 from domain.entities import User
 from application.use_cases import AccessRequestUseCases
+
+# Imports necesarios para los nuevos endpoints
+from infrastructure.database import get_db
+from infrastructure.postgres import PostgresNotificationRepository, PostgresAuditLogRepository
 
 router = APIRouter(tags=["AccessFlow API"])
 
@@ -39,7 +44,6 @@ def login(
     form_data: OAuth2PasswordRequestForm = Depends(), 
     user_repo = Depends(get_user_repository)
 ):
-    # OAuth2PasswordRequestForm usa 'username' por defecto, nosotros lo tratamos como 'email'
     user = user_repo.get_by_email(form_data.username)
     
     if not user or not AuthProvider.verify_password(form_data.password, user.hashed_password):
@@ -141,13 +145,21 @@ def provision_request(
     return map_to_response(req)
 
 # ============================================================
-# Utility Endpoints (Mocks pendientes Issue de Observers)
+# Utility Endpoints (Notificaciones y Auditoría Reales)
 # ============================================================
 
 @router.get("/notifications", response_model=List[NotificationResponse], tags=["Utility"])
-def get_notifications(current_user: User = Depends(get_current_user)):
-    return []
+def get_notifications(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    repo = PostgresNotificationRepository(db)
+    return repo.get_by_user(current_user.id)
 
 @router.get("/audit-log", response_model=List[AuditLogResponse], tags=["Utility"])
-def get_audit_log(current_user: User = Depends(require_role(UserRole.SYSTEM_ADMIN))):
-    return []
+def get_audit_log(
+    current_user: User = Depends(require_role(UserRole.SYSTEM_ADMIN)),
+    db: Session = Depends(get_db)
+):
+    repo = PostgresAuditLogRepository(db)
+    return repo.get_all()

--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -1,8 +1,9 @@
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
 
 from application.dtos import (
-    LoginRequest, TokenResponse, CreateAccessRequestDTO, 
+    TokenResponse, CreateAccessRequestDTO, 
     AccessRequestResponse, ActionReasonDTO, 
     NotificationResponse, AuditLogResponse
 )
@@ -34,10 +35,14 @@ def map_to_response(req) -> AccessRequestResponse:
 # ============================================================
 
 @router.post("/auth/login", response_model=TokenResponse, tags=["Authentication"])
-def login(request: LoginRequest, user_repo = Depends(get_user_repository)):
-    user = user_repo.get_by_email(request.email)
+def login(
+    form_data: OAuth2PasswordRequestForm = Depends(), 
+    user_repo = Depends(get_user_repository)
+):
+    # OAuth2PasswordRequestForm usa 'username' por defecto, nosotros lo tratamos como 'email'
+    user = user_repo.get_by_email(form_data.username)
     
-    if not user or not AuthProvider.verify_password(request.password, user.hashed_password):
+    if not user or not AuthProvider.verify_password(form_data.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Email o contraseña incorrectos",

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2,15 +2,14 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from api.endpoints import router as api_router
+from api.dependencies import setup_dependencies, get_user_repository
 from domain.enums import UserRole
 from domain.entities import User
 from infrastructure.auth_provider import AuthProvider
-from api.dependencies import get_user_repository
+from infrastructure.database import create_all_tables
 
 def seed_test_users():
-    """Verifica y crea los usuarios de prueba en la base de datos si no existen."""
     user_repo = get_user_repository()
-    
     users_to_seed = [
         {"name": "System Admin", "email": "admin@accessflow.com", "password": "admin123", "role": UserRole.SYSTEM_ADMIN},
         {"name": "Employee", "email": "employee@accessflow.com", "password": "employee123", "role": UserRole.EMPLOYEE},
@@ -18,41 +17,26 @@ def seed_test_users():
         {"name": "Security Reviewer", "email": "security@accessflow.com", "password": "security123", "role": UserRole.SECURITY_REVIEWER},
         {"name": "IT Admin", "email": "itadmin@accessflow.com", "password": "itadmin123", "role": UserRole.IT_ADMIN},
     ]
-    
     for u_data in users_to_seed:
         if not user_repo.get_by_email(u_data["email"]):
             hashed_pw = AuthProvider.get_password_hash(u_data["password"])
-            
             new_user = User(
                 name=u_data["name"],
                 email=u_data["email"],
                 hashed_password=hashed_pw,
                 role=u_data["role"]
             )
-            
-            # Cambiado a "add" para coincidir con la nueva interfaz
             user_repo.add(new_user)
             print(f"✅ Usuario semilla creado: {u_data['email']} [{u_data['role'].value}]")
 
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # --- Startup Event ---
     print("Iniciando AccessFlow API...")
-    
-    # Intenta crear las tablas si el archivo de DB ya existe
-    try:
-        from infrastructure.database import create_all_tables
-        create_all_tables()
-        print("Tablas de base de datos validadas/creadas.")
-    except ImportError:
-        pass # Ignorar si Persona 3 aún no ha subido el archivo database.py
-        
+    create_all_tables()
+    setup_dependencies()   # ← Inicializa repos reales y observers
     seed_test_users()
     yield
-    # --- Shutdown Event ---
     print("Apagando AccessFlow API...")
-
 
 app = FastAPI(
     title="AccessFlow API",
@@ -61,5 +45,4 @@ app = FastAPI(
     lifespan=lifespan
 )
 
-# Registrar las rutas
 app.include_router(api_router)

--- a/backend/application/dtos.py
+++ b/backend/application/dtos.py
@@ -4,9 +4,6 @@ from datetime import date, datetime
 from domain.enums import AccessLevel, SystemType
 
 # --- Auth DTOs ---
-class LoginRequest(BaseModel):
-    email: str
-    password: str
 
 class TokenResponse(BaseModel):
     access_token: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ pydantic==2.5.0
 pydantic-settings==2.1.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
+bcrypt==3.2.2
 python-multipart==0.0.6
 python-dotenv==1.0.0
 pytest==7.4.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,8 @@ services:
       - accessflow-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U accessflow_user"]
+      # CORRECCIÓN: Agregado el parámetro -d para especificar la base de datos
+      test: ["CMD-SHELL", "pg_isready -U accessflow_user -d accessflow_db"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,1 @@
+print("Frontend")


### PR DESCRIPTION
Integración final de la base de datos PostgreSQL, EventBus y correcciones de despliegue para el backend.

### Cambios realizados:
- Se implementaron los repositorios y observers reales en `dependencies.py`.
- Se configuró el `lifespan` en `main.py` para levantar la BD y ejecutar el *seed* de usuarios correctamente.
- Se forzó la versión de `bcrypt==3.2.2` en `requirements.txt` para evitar conflictos de compatibilidad con `passlib` durante el hasheo de contraseñas.
- Se actualizó el endpoint de `/auth/login` para utilizar `OAuth2PasswordRequestForm`, permitiendo la autenticación nativa desde el botón "Authorize" de Swagger UI.
- Se corrigieron las rutas y comandos de inicio en `Dockerfile` y `docker-compose.yml` para respetar la arquitectura hexagonal.

El backend ahora está 100% funcional y listo para que el frontend empiece a consumir los endpoints.

Closes #105