### PR TITLE
feat: vistas de Manager y Security Reviewer

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -26,12 +26,15 @@ def map_to_response(req) -> AccessRequestResponse:
     return AccessRequestResponse(
         id=str(req.id),
         requester_id=req.requester_id,
+        requester_name=req.requester_name,
         target_system=req.target_system,
         access_level=req.access_level.value,
         justification=req.justification,
         system_type=req.system_type.value,
         expiration_date=req.expiration_date,
         status=req.status.value,
+        rejection_reason=req.rejection_reason,
+        changes_requested_comment=req.changes_requested_comment,
         created_at=req.created_at
     )
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -16,16 +16,20 @@ def seed_test_users():
         {"name": "Manager", "email": "manager@accessflow.com", "password": "manager123", "role": UserRole.MANAGER},
         {"name": "Security Reviewer", "email": "security@accessflow.com", "password": "security123", "role": UserRole.SECURITY_REVIEWER},
         {"name": "IT Admin", "email": "itadmin@accessflow.com", "password": "itadmin123", "role": UserRole.IT_ADMIN},
+        {"id": "SYSTEM", "name": "System Automated", "email": "system@accessflow.com", "password": "system123", "role": UserRole.SYSTEM_ADMIN},
     ]
     for u_data in users_to_seed:
         if not user_repo.get_by_email(u_data["email"]):
             hashed_pw = AuthProvider.get_password_hash(u_data["password"])
-            new_user = User(
-                name=u_data["name"],
-                email=u_data["email"],
-                hashed_password=hashed_pw,
-                role=u_data["role"]
-            )
+            user_args = {
+                "name": u_data["name"],
+                "email": u_data["email"],
+                "hashed_password": hashed_pw,
+                "role": u_data["role"]
+            }
+            if "id" in u_data:
+                user_args["id"] = u_data["id"]
+            new_user = User(**user_args)
             user_repo.add(new_user)
             print(f"✅ Usuario semilla creado: {u_data['email']} [{u_data['role'].value}]")
 

--- a/backend/application/dtos.py
+++ b/backend/application/dtos.py
@@ -31,6 +31,8 @@ class AccessRequestResponse(BaseModel):
     system_type: Optional[str] = None
     expiration_date: Optional[date] = None
     status: str
+    rejection_reason: Optional[str] = None
+    changes_requested_comment: Optional[str] = None
     created_at: datetime
 
 # --- Utility DTOs ---

--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -62,13 +62,18 @@ class CreateRequestCommand(RequestCommand):
 class SubmitRequestCommand(RequestCommand):
     """
     Comando para enviar la solicitud a revisión.
-    Transiciona de DRAFT a SUBMITTED.
+    Transiciona de DRAFT a SUBMITTED y luego automáticamente a MANAGER_REVIEW.
     """
 
     def execute(self) -> None:
         self.request.submit()
         event = AccessRequestSubmittedEvent(request=self.request)
         self.event_bus.publish(event)
+        
+        # El sistema la mueve automáticamente a MANAGER_REVIEW
+        from domain.enums import RequestStatus
+        self.request._transition_to(RequestStatus.MANAGER_REVIEW)
+        
         manager_event = ManagerApprovalRequiredEvent(request=self.request)
         self.event_bus.publish(manager_event)
 

--- a/frontend/api_client.py
+++ b/frontend/api_client.py
@@ -11,8 +11,8 @@ class AccessFlowClient:
 
     def login(self, email: str, password: str) -> dict:
         url = f"{self.base_url}/auth/login"
-        payload = {"email": email, "password": password}
-        response = self.session.post(url, json=payload)
+        payload = {"username": email, "password": password}
+        response = self.session.post(url, data=payload)
         response.raise_for_status()
         data = response.json()
         self.set_token(data["access_token"])
@@ -42,5 +42,23 @@ class AccessFlowClient:
             payload["expiration_date"] = expiration_date
 
         response = self.session.post(url, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    def approve_request(self, request_id: str) -> dict:
+        url = f"{self.base_url}/requests/{request_id}/approve"
+        response = self.session.post(url)
+        response.raise_for_status()
+        return response.json()
+
+    def reject_request(self, request_id: str, reason: str) -> dict:
+        url = f"{self.base_url}/requests/{request_id}/reject"
+        response = self.session.post(url, json={"reason": reason})
+        response.raise_for_status()
+        return response.json()
+
+    def request_changes(self, request_id: str, reason: str) -> dict:
+        url = f"{self.base_url}/requests/{request_id}/request-changes"
+        response = self.session.post(url, json={"reason": reason})
         response.raise_for_status()
         return response.json()

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,7 +1,11 @@
 import streamlit as st
 import requests
 from api_client import AccessFlowClient
-from datetime import date
+
+# Importar las vistas
+from views.employee import page_my_requests, page_new_request
+from views.manager import page_manager_dashboard
+from views.security import page_security_dashboard
 
 # Configuracion de página
 st.set_page_config(page_title="AccessFlow", page_icon="🔐", layout="wide")
@@ -52,12 +56,22 @@ def render_sidebar():
     role = st.session_state.role
     st.sidebar.markdown(f"**Rol:** {role}")
     
-    # Menú dependiendo del rol
+    # Opciones de navegación dependiendo del rol
     selected_page = None
     if role == "EMPLOYEE":
         selected_page = st.sidebar.radio(
             "Navegación",
             ["Mis Solicitudes", "Nueva Solicitud"]
+        )
+    elif role == "MANAGER":
+        selected_page = st.sidebar.radio(
+            "Navegación",
+            ["Bandeja de Aprobación"]
+        )
+    elif role == "SECURITY_REVIEWER":
+        selected_page = st.sidebar.radio(
+            "Navegación",
+            ["Revisión de Seguridad"]
         )
     else:
         st.sidebar.info(f"Vistas para el rol {role} se implementarán posteriormente.")
@@ -69,91 +83,6 @@ def render_sidebar():
         
     return selected_page
 
-def page_my_requests():
-    st.title("Mis Solicitudes")
-    client = st.session_state.client
-    
-    try:
-        requests_list = client.get_requests()
-        if not requests_list:
-            st.info("No tienes solicitudes creadas.")
-            return
-        
-        # Muestra un listado, usando expanders para el detalle
-        for req in requests_list:
-            status_color = "🟢" if req["status"] == "APPROVED" else "🟡" if req["status"] in ["DRAFT", "SUBMITTED", "MANAGER_REVIEW", "SECURITY_REVIEW"] else "🔴"
-            with st.expander(f"{status_color} {req['target_system']} - {req['access_level']} ({req['status']})"):
-                st.write(f"**ID:** `{req['id']}`")
-                st.write(f"**Estado:** `{req['status']}`")
-                st.write(f"**Nivel de Acceso:** `{req['access_level']}`")
-                st.write(f"**Sistema:** `{req['target_system']}` ({req['system_type']})")
-                st.write(f"**Fecha Creación:** `{req['created_at']}`")
-                if req.get('expiration_date'):
-                    st.write(f"**Expira:** `{req['expiration_date']}`")
-                st.write(f"**Justificación:** {req['justification']}")
-                
-    except Exception as e:
-        st.error(f"Error al obtener solicitudes: {e}")
-
-def page_new_request():
-    st.title("Nueva Solicitud de Acceso")
-    client = st.session_state.client
-    
-    target_system = st.text_input("Sistema Destino", placeholder="Ej. Base de datos de clientes")
-    
-    system_types = ["GITHUB", "DATABASE", "DASHBOARD", "CRM", "SUPPORT", "CLOUD", "ADMIN_PANEL", "PRODUCTIVE_DATABASE", "OTHER"]
-    system_type = st.selectbox("Tipo de Sistema", system_types)
-    
-    access_levels = ["READ", "WRITE", "ADMIN"]
-    access_level = st.selectbox("Nivel de Acceso Requerido", access_levels)
-    
-    justification = st.text_area("Justificación", placeholder="Motivo por el cual necesitas este acceso...")
-    
-    # Lógica condicional para la fecha de expiración
-    if access_level == "ADMIN":
-        st.warning("El nivel ADMIN requiere obligatoriamente una fecha de expiración.")
-        exp_date_input = st.date_input("Fecha de Expiración", min_value=date.today())
-        expiration_date = exp_date_input.isoformat()
-    else:
-        use_exp_date = st.checkbox("¿Deseas establecer una fecha de expiración? (Opcional)")
-        if use_exp_date:
-            exp_date_input = st.date_input("Fecha de Expiración", min_value=date.today())
-            expiration_date = exp_date_input.isoformat()
-        else:
-            expiration_date = None
-            
-    if st.button("Crear Solicitud", type="primary"):
-        if not target_system or len(target_system) < 2:
-            st.error("El Sistema Destino debe tener al menos 2 caracteres.")
-        elif not justification or len(justification) < 5:
-            st.error("La Justificación debe tener al menos 5 caracteres.")
-        elif access_level == "ADMIN" and not expiration_date:
-            st.error("Para nivel ADMIN, debes proporcionar una fecha de expiración válida.")
-        elif expiration_date and exp_date_input <= date.today():
-            st.error("La fecha de expiración no puede ser hoy. Debe ser una fecha futura.")
-        else:
-            try:
-                res = client.create_request(
-                    target_system=target_system,
-                    access_level=access_level,
-                    justification=justification,
-                    system_type=system_type,
-                    expiration_date=expiration_date
-                )
-                st.success(f"Solicitud creada exitosamente con ID: {res['id']}")
-            except requests.exceptions.HTTPError as e:
-                try:
-                    err_msg = e.response.json().get("detail", str(e))
-                    if isinstance(err_msg, list):
-                        msgs = [f"- {err.get('loc', [''])[-1]}: {err.get('msg', '')}" for err in err_msg]
-                        st.error("Error de validación del servidor:\n" + "\n".join(msgs))
-                    else:
-                        st.error(f"Error devuelto por el servidor: {err_msg}")
-                except Exception:
-                    st.error(f"Error al crear la solicitud: {e}")
-            except Exception as e:
-                st.error(f"Error inesperado: {e}")
-
 def main():
     _init_session()
     
@@ -161,10 +90,16 @@ def main():
         page_login()
     else:
         page = render_sidebar()
+        
+        # Enrutamiento de vistas
         if page == "Mis Solicitudes":
             page_my_requests()
         elif page == "Nueva Solicitud":
             page_new_request()
+        elif page == "Bandeja de Aprobación":
+            page_manager_dashboard()
+        elif page == "Revisión de Seguridad":
+            page_security_dashboard()
         elif page == "Pendiente":
             st.title("Pantalla Pendiente")
             st.info("Funcionalidad no implementada en esta fase.")

--- a/frontend/views/__init__.py
+++ b/frontend/views/__init__.py
@@ -1,0 +1,1 @@
+# Empty init

--- a/frontend/views/employee.py
+++ b/frontend/views/employee.py
@@ -1,0 +1,92 @@
+import streamlit as st
+from datetime import date
+import requests
+
+def page_my_requests():
+    st.title("Mis Solicitudes")
+    client = st.session_state.client
+    
+    try:
+        requests_list = client.get_requests()
+        if not requests_list:
+            st.info("No tienes solicitudes creadas.")
+            return
+        
+        # Muestra un listado, usando expanders para el detalle
+        for req in requests_list:
+            status_color = "🟢" if req["status"] == "APPROVED" else "🟡" if req["status"] in ["DRAFT", "SUBMITTED", "MANAGER_REVIEW", "SECURITY_REVIEW"] else "🔴"
+            with st.expander(f"{status_color} {req['target_system']} - {req['access_level']} ({req['status']})"):
+                st.write(f"**ID:** `{req['id']}`")
+                st.write(f"**Estado:** `{req['status']}`")
+                st.write(f"**Nivel de Acceso:** `{req['access_level']}`")
+                st.write(f"**Sistema:** `{req['target_system']}` ({req['system_type']})")
+                st.write(f"**Fecha Creación:** `{req['created_at'][:10]}`")
+                if req.get('expiration_date'):
+                    st.write(f"**Expira:** `{req['expiration_date']}`")
+                st.write(f"**Justificación:** {req['justification']}")
+                if req['status'] == "REJECTED" and req.get('rejection_reason'):
+                    st.error(f"**Motivo del rechazo:** {req['rejection_reason']}")
+                if req['status'] == "CHANGES_REQUESTED" and req.get('changes_requested_comment'):
+                    st.warning(f"**Cambios solicitados:** {req['changes_requested_comment']}")
+                
+    except Exception as e:
+        st.error(f"Error al obtener solicitudes: {e}")
+
+def page_new_request():
+    st.title("Nueva Solicitud de Acceso")
+    client = st.session_state.client
+    
+    target_system = st.text_input("Sistema Destino", placeholder="Ej. Base de datos de clientes")
+    
+    system_types = ["GITHUB", "DATABASE", "DASHBOARD", "CRM", "SUPPORT", "CLOUD", "ADMIN_PANEL", "PRODUCTIVE_DATABASE", "OTHER"]
+    system_type = st.selectbox("Tipo de Sistema", system_types)
+    
+    access_levels = ["READ", "WRITE", "ADMIN"]
+    access_level = st.selectbox("Nivel de Acceso Requerido", access_levels)
+    
+    justification = st.text_area("Justificación", placeholder="Motivo por el cual necesitas este acceso...")
+    
+    # Lógica condicional para la fecha de expiración
+    if access_level == "ADMIN":
+        st.warning("El nivel ADMIN requiere obligatoriamente una fecha de expiración.")
+        exp_date_input = st.date_input("Fecha de Expiración", min_value=date.today())
+        expiration_date = exp_date_input.isoformat()
+    else:
+        use_exp_date = st.checkbox("¿Deseas establecer una fecha de expiración? (Opcional)")
+        if use_exp_date:
+            exp_date_input = st.date_input("Fecha de Expiración", min_value=date.today())
+            expiration_date = exp_date_input.isoformat()
+        else:
+            expiration_date = None
+            
+    if st.button("Crear Solicitud", type="primary"):
+        if not target_system or len(target_system) < 2:
+            st.error("El Sistema Destino debe tener al menos 2 caracteres.")
+        elif not justification or len(justification) < 5:
+            st.error("La Justificación debe tener al menos 5 caracteres.")
+        elif access_level == "ADMIN" and not expiration_date:
+            st.error("Para nivel ADMIN, debes proporcionar una fecha de expiración válida.")
+        elif expiration_date and exp_date_input <= date.today():
+            st.error("La fecha de expiración no puede ser hoy. Debe ser una fecha futura.")
+        else:
+            try:
+                res = client.create_request(
+                    target_system=target_system,
+                    access_level=access_level,
+                    justification=justification,
+                    system_type=system_type,
+                    expiration_date=expiration_date
+                )
+                st.success(f"Solicitud creada exitosamente con ID: {res['id']}")
+            except requests.exceptions.HTTPError as e:
+                try:
+                    err_msg = e.response.json().get("detail", str(e))
+                    if isinstance(err_msg, list):
+                        msgs = [f"- {err.get('loc', [''])[-1]}: {err.get('msg', '')}" for err in err_msg]
+                        st.error("Error de validación del servidor:\n" + "\n".join(msgs))
+                    else:
+                        st.error(f"Error devuelto por el servidor: {err_msg}")
+                except Exception:
+                    st.error(f"Error al crear la solicitud: {e}")
+            except Exception as e:
+                st.error(f"Error inesperado: {e}")

--- a/frontend/views/manager.py
+++ b/frontend/views/manager.py
@@ -1,0 +1,67 @@
+import streamlit as st
+import requests
+
+def page_manager_dashboard():
+    st.title("Bandeja de Aprobación - Manager")
+    client = st.session_state.client
+    
+    try:
+        all_requests = client.get_requests()
+        # Filtramos por estado MANAGER_REVIEW
+        pending_requests = [req for req in all_requests if req["status"] == "MANAGER_REVIEW"]
+        
+        if not pending_requests:
+            st.info("No hay solicitudes pendientes de aprobación por el momento.")
+            return
+            
+        for req in pending_requests:
+            with st.expander(f"🟡 {req['target_system']} - {req['access_level']} (Usuario: {req['requester_id']})"):
+                st.write(f"**ID Solicitud:** `{req['id']}`")
+                st.write(f"**Nivel de Acceso:** `{req['access_level']}`")
+                st.write(f"**Sistema:** `{req['target_system']}` ({req['system_type']})")
+                st.write(f"**Justificación:** {req['justification']}")
+                if req.get('expiration_date'):
+                    st.write(f"**Fecha Expiración:** `{req['expiration_date']}`")
+                
+                st.divider()
+                st.markdown("### Acciones")
+                
+                col1, col2, col3 = st.columns(3)
+                
+                with col1:
+                    if st.button("✅ Aprobar", key=f"btn_approve_{req['id']}", type="primary"):
+                        try:
+                            client.approve_request(req['id'])
+                            st.success(f"Solicitud {req['id']} aprobada correctamente.")
+                            st.rerun()
+                        except Exception as e:
+                            st.error(f"Error al aprobar: {e}")
+                
+                with col2:
+                    reason_reject = st.text_input("Motivo de rechazo", key=f"reason_reject_{req['id']}")
+                    if st.button("❌ Rechazar", key=f"btn_reject_{req['id']}"):
+                        if not reason_reject:
+                            st.warning("Debes proporcionar un motivo para rechazar.")
+                        else:
+                            try:
+                                client.reject_request(req['id'], reason_reject)
+                                st.success(f"Solicitud {req['id']} rechazada.")
+                                st.rerun()
+                            except Exception as e:
+                                st.error(f"Error al rechazar: {e}")
+                
+                with col3:
+                    reason_changes = st.text_input("Comentario para cambios", key=f"reason_changes_{req['id']}")
+                    if st.button("🔄 Solicitar Cambios", key=f"btn_changes_{req['id']}"):
+                        if not reason_changes:
+                            st.warning("Debes proporcionar un comentario para solicitar cambios.")
+                        else:
+                            try:
+                                client.request_changes(req['id'], reason_changes)
+                                st.success(f"Se han solicitado cambios para {req['id']}.")
+                                st.rerun()
+                            except Exception as e:
+                                st.error(f"Error al solicitar cambios: {e}")
+                                
+    except Exception as e:
+        st.error(f"Error al obtener las solicitudes: {e}")

--- a/frontend/views/security.py
+++ b/frontend/views/security.py
@@ -1,0 +1,54 @@
+import streamlit as st
+import requests
+
+def page_security_dashboard():
+    st.title("Revisión de Seguridad")
+    client = st.session_state.client
+    
+    try:
+        all_requests = client.get_requests()
+        # Filtramos por estado SECURITY_REVIEW
+        pending_requests = [req for req in all_requests if req["status"] == "SECURITY_REVIEW"]
+        
+        if not pending_requests:
+            st.info("No hay solicitudes que requieran revisión de seguridad por el momento.")
+            return
+            
+        for req in pending_requests:
+            with st.expander(f"🛡️ {req['target_system']} - {req['access_level']} (Usuario: {req['requester_id']})"):
+                st.write(f"**ID Solicitud:** `{req['id']}`")
+                st.write(f"**Nivel de Acceso:** `{req['access_level']}`")
+                st.write(f"**Sistema:** `{req['target_system']}` ({req['system_type']})")
+                st.write(f"**Justificación:** {req['justification']}")
+                if req.get('expiration_date'):
+                    st.write(f"**Fecha Expiración:** `{req['expiration_date']}`")
+                
+                st.divider()
+                st.markdown("### Acciones de Seguridad")
+                
+                col1, col2 = st.columns(2)
+                
+                with col1:
+                    if st.button("✅ Aprobar Acceso", key=f"sec_approve_{req['id']}", type="primary"):
+                        try:
+                            client.approve_request(req['id'])
+                            st.success(f"Solicitud {req['id']} aprobada de forma segura.")
+                            st.rerun()
+                        except Exception as e:
+                            st.error(f"Error al aprobar: {e}")
+                
+                with col2:
+                    reason_reject = st.text_input("Motivo de rechazo de seguridad", key=f"sec_reason_reject_{req['id']}")
+                    if st.button("❌ Rechazar Acceso", key=f"sec_reject_{req['id']}"):
+                        if not reason_reject:
+                            st.warning("Debes proporcionar un motivo de seguridad para rechazar.")
+                        else:
+                            try:
+                                client.reject_request(req['id'], reason_reject)
+                                st.success(f"Solicitud {req['id']} rechazada por seguridad.")
+                                st.rerun()
+                            except Exception as e:
+                                st.error(f"Error al rechazar: {e}")
+                                
+    except Exception as e:
+        st.error(f"Error al obtener las solicitudes: {e}")


### PR DESCRIPTION
## Resumen
Se implementa las bandejas de revisión y aprobación en el frontend para los roles de `Manager` y `Security Reviewer`. Además, corrige dos bugs en el backend que impedían el correcto funcionamiento del flujo de estados y la inserción de logs de auditoría.

---

## Issues Resueltos
- Issue #94 
-  Issue #95 

---

## Cambios Realizados

### Frontend (`frontend/`)
- `views/manager.py`: Nueva vista para el rol de Manager con componentes tipo expander y botones funcionales.
- `views/security.py`: Nueva vista para el rol de Security Reviewer con validaciones de seguridad.
- `api_client.py`: Se extendió el cliente HTTP para conectar los endpoints de aprobación (`approve_request`, `reject_request`, `request_changes`).

### Backend (`backend/`)
- `domain/commands.py`: Se modificó `SubmitRequestCommand` para transicionar automáticamente las solicitudes recién creadas de `SUBMITTED` a `MANAGER_REVIEW`, reparando el flujo del ciclo de vida.
- `api/main.py`: Se reparó un Error 500 al insertar logs de auditoría automáticos. Ahora se inyecta correctamente un usuario de sistema (`"id": "SYSTEM"`) en la función de inicialización `seed_test_users()` para respetar las llaves foráneas.
- `application/dtos.py` & `api/endpoints.py`: Se añadieron los campos `rejection_reason` y `changes_requested_comment` a las respuestas para que el frontend pueda informar al empleado.

## Checklist:

### Manager:
- [x] Solo las solicitudes de su equipo (filtradas por el estado `MANAGER_REVIEW`).
- [x] Puede aprobar una solicitud (cambia de estado según el flujo).
- [x] Puede rechazar una solicitud con motivo (campo dinámico).
- [x] Puede solicitar cambios con comentario (campo dinámico).
- [x] Las acciones de aprobación/rechazo/cambios se reflejan en tiempo real en la UI.

### Security Reviewer:
- [x] Ve solo las solicitudes de su cola (nivel ADMIN o sistemas sensibles, filtradas por `SECURITY_REVIEW`).
- [x] Puede aprobar una solicitud (cambia estado a aprobado o trigger a IT provisioning).
- [x] Puede rechazar la solicitud exigiendo un motivo de seguridad.
- [x] Las acciones se reflejan en tiempo real en la UI.
